### PR TITLE
Force light theme to be used for pages

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Layout from '@theme/Layout';
 import Hero from '../components/Hero';
 import OpenFinance from '../components/OpenFinance';
@@ -7,6 +7,10 @@ import HowItWorks from '../components/HowItWorks';
 import Tokenomics from '../components/Tokenomics';
 
 export default function Home() {
+    useEffect(() => {
+        document.getElementsByTagName('html')[0].setAttribute('data-theme', 'light');
+    })
+
     return (
         <Layout
             title="Yellow DeFi - Discover WEB 3.0 Internet of Finance"


### PR DESCRIPTION
Using this "hack" to only override the index page theme, without changing user preference on other pages (docs, blog).