### PR TITLE
Update links

### DIFF
--- a/src/components/Hero/index.js
+++ b/src/components/Hero/index.js
@@ -19,7 +19,7 @@ export default function Hero() {
                             <div className="hero__buttons">
                                 <Link
                                     className="button button--secondary margin-right--md"
-                                    to="/docs/overview/what-is-xln">
+                                    to="/docs/concepts/architecture">
                                     <span className="button__inner">Docs</span>
                                 </Link>
                                 <Link


### PR DESCRIPTION
@josadcha Litepaper button is already has updated link (“/docs/concepts/architecture”) please notify if it still should be replaced with another link